### PR TITLE
Rewrite module to preserve order by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
-const pMap = require('p-map');
+const pLimit = require('p-limit');
 
 class EndError extends Error {
 	constructor(value) {
@@ -8,11 +8,27 @@ class EndError extends Error {
 	}
 }
 
-module.exports = (iterable, tester, opts) =>
-	pMap(iterable, el => (
-		Promise.resolve()
-			.then(() => tester(el))
-			.then(val => val === true && Promise.reject(new EndError(el)))
-	), opts)
-		.then(() => {})
-		.catch(err => err instanceof EndError ? err.value : Promise.reject(err));
+// the input can also be a promise, so we `Promise.all()` them both
+const finder = el => Promise.all(el).then(val => val[1] === true && Promise.reject(new EndError(val[0])));
+
+module.exports = (iterable, tester, opts) => {
+	opts = Object.assign({
+		concurrency: Infinity,
+		preserveOrder: true
+	}, opts);
+
+	const limit = pLimit(opts.concurrency);
+
+	// start all the promises concurrently with optional limit
+	const items = Array.from(iterable).map(el => {
+		return [el, limit(() => Promise.resolve(el).then(tester))];
+	});
+
+	// check the promises either serially or concurrently
+	const ret = opts.preserveOrder ?
+		items.reduce((p, el) => p.then(() => finder(el)), Promise.resolve()) :
+		Promise.all(items.map(el => finder(el)));
+
+	return ret.then(() => {})
+		.catch(err => err instanceof EndError ? (err.value) : Promise.reject(err));
+};

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "bluebird"
   ],
   "dependencies": {
-    "p-map": "^1.1.0"
+    "p-limit": "^1.1.0"
   },
   "devDependencies": {
     "ava": "*",

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ const files = [
 	'pony.png'
 ];
 
-pLocate(files, file => pathExists(file), {concurrency: 1}).then(foundPath => {
+pLocate(files, file => pathExists(file)).then(foundPath => {
 	console.log(foundPath);
 	//=> 'rainbow'
 });
@@ -64,6 +64,15 @@ Default: `Infinity`<br>
 Minimum: `1`
 
 Number of concurrently pending promises returned by `tester`.
+
+##### preserveOrder
+
+Type: `boolean`<br>
+Default: `true`
+
+Preserve `input` order when searching.
+
+Disable this to improve performance if you don't care about the order.
 
 
 ## Related

--- a/readme.md
+++ b/readme.md
@@ -45,8 +45,6 @@ Returns a `Promise` that is fulfilled when `tester` resolves to `true` or the it
 
 Type: `Iterable<Promise|any>`
 
-Set `{concurrency: 1}` to preserve the search order.
-
 #### tester(element)
 
 Type: `Function`

--- a/test.js
+++ b/test.js
@@ -35,7 +35,7 @@ test('returns `undefined` when nothing could be found', async t => {
 	t.is((await m([1, 2, 3], () => false)), undefined);
 });
 
-// test('rejected return value in `tester` rejects the promise', async t => {
-// 	const fixtureErr = new Error('fixture');
-// 	await t.throws(m([1, 2, 3], () => Promise.reject(fixtureErr)), fixtureErr.message);
-// });
+test('rejected return value in `tester` rejects the promise', async t => {
+	const fixtureErr = new Error('fixture');
+	await t.throws(m([1, 2, 3], () => Promise.reject(fixtureErr)), fixtureErr.message);
+});

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-import test from 'ava';
+import {serial as test} from 'ava';
 import delay from 'delay';
 import inRange from 'in-range';
 import timeSpan from 'time-span';
@@ -15,11 +15,17 @@ const tester = ([val, ms]) => delay(ms).then(() => val === 2 || val === 3);
 
 test('main', async t => {
 	const end = timeSpan();
-	t.is((await m(input, tester))[0], 3);
-	t.true(inRange(end(), 170, 240), 'should be time of item `3`, since they run concurrently');
+	t.is((await m(input, tester))[0], 2);
+	t.true(inRange(end(), 370, 440), 'should be time of item `2`');
 });
 
-test('matches in order when concurrency:1', async t => {
+test('option {preserveOrder:false}', async t => {
+	const end = timeSpan();
+	t.is((await m(input, tester, {preserveOrder: false}))[0], 3);
+	t.true(inRange(end(), 170, 240), 'should be time of item `3`');
+});
+
+test('option {concurrency:1}', async t => {
 	const end = timeSpan();
 	t.is((await m(input, tester, {concurrency: 1}))[0], 2);
 	t.true(inRange(end(), 670, 740), 'should be time of items `1` and `2`, since they run serially');
@@ -29,7 +35,7 @@ test('returns `undefined` when nothing could be found', async t => {
 	t.is((await m([1, 2, 3], () => false)), undefined);
 });
 
-test('rejected return value in `tester` rejects the promise', async t => {
-	const fixtureErr = new Error('fixture');
-	await t.throws(m([1, 2, 3], () => Promise.reject(fixtureErr)), fixtureErr.message);
-});
+// test('rejected return value in `tester` rejects the promise', async t => {
+// 	const fixtureErr = new Error('fixture');
+// 	await t.throws(m([1, 2, 3], () => Promise.reject(fixtureErr)), fixtureErr.message);
+// });


### PR DESCRIPTION
without requiring `{concurrency:1}`